### PR TITLE
Added missing variable for max_page logging

### DIFF
--- a/tap_rest_api/sync.py
+++ b/tap_rest_api/sync.py
@@ -146,7 +146,7 @@ def sync_rows(config, state, tap_stream_id, key_properties=[], auth_method=None,
                             config["items_per_page"])
                 break
             if max_page and page_number + 1 >= max_page:
-                LOGGER.info("Max page %d reached. Finishing the extraction.")
+                LOGGER.info("Max page %d reached. Finishing the extraction." % max_page)
                 break
             if assume_sorted and end and next_last_update >= end:
                 LOGGER.info(("Record greater than %s and assume_sorted is" +


### PR DESCRIPTION
The max_page variable is missing for the logger.info message when max_page is reach