### PR TITLE
Bounded, fully-drained time windows (opt-in) for incremental replication

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@
   checkpoint the bookmark only after a window fully drains, so a timeout cannot leapfrog
   past unfetched records. Opt-in; unset keeps the existing single-request behavior.
 - fix: log schema-validation failures with the reason and the offending record.
+- fix (#38): `get_end()` now uses a UTC "now" instead of naive local `datetime.now()`,
+  and the windowing param builder converts window epochs as UTC — the incremental end
+  bound no longer skews on a non-UTC host.
+- fix (#39): the bookmark-key type-validation asserts now actually run; they were
+  written as `assert(cond, "msg")` (a always-true tuple) and never fired.
+- fix (#40): popping the extract-timestamp before persisting `last_record_extracted`
+  no longer raises `KeyError` when the stream's schema does not declare `_sdc_extracted_at`.
 
 ### 0.2.17 (2026-03-30)
 - fix: Unblock other streams after one experiences an error

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 ## History
 
+### 0.2.18 (2026-07-11)
+- feature: bounded, fully-drained time windows (`window_size_seconds`/`window_size_hours`).
+  With a datetime/timestamp bookmark, replicate in contiguous half-open windows and
+  checkpoint the bookmark only after a window fully drains, so a timeout cannot leapfrog
+  past unfetched records. Opt-in; unset keeps the existing single-request behavior.
+- fix: log schema-validation failures with the reason and the offending record.
+
 ### 0.2.17 (2026-03-30)
 - fix: Unblock other streams after one experiences an error
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,33 @@
-[![Build Status](https://travis-ci.com/anelendata/tap-rest-api.svg?branch=master)](https://travis-ci.com/anelendata/tap-rest-api)
-
-💥 New in 0.2.0: Set record_list_level and record_level, index_key, datetime_key, and timestamp_key with jsonpath.
+[![PyPI version](https://img.shields.io/pypi/v/tap-rest-api.svg)](https://pypi.org/project/tap-rest-api/)
+[![Python versions](https://img.shields.io/pypi/pyversions/tap-rest-api.svg)](https://pypi.org/project/tap-rest-api/)
 
 # tap-rest-api
 
-A configurable REST API singer.io tap.
+A configurable REST API [Singer](https://singer.io) tap.
+
+> See [HISTORY.md](HISTORY.md) for the changelog. **Latest (0.2.18):** bounded,
+> fully-drained time windows for safe incremental replication — see
+> [Incremental replication: `assume_sorted` and windowing](#incremental-replication-assume_sorted-and-windowing).
+
+## Contents
+
+- [What is it?](#what-is-it)
+- [Install](#install)
+- [Quick start (USGS example)](#quick-start-usgs-example)
+- [Configuration](#configuration)
+  - [Parametric URL](#parametric-url)
+  - [Bookmark keys: `timestamp_key`, `datetime_key`, `index_key`](#bookmark-keys-timestamp_key-datetime_key-index_key)
+  - [Incremental replication: `assume_sorted` and windowing](#incremental-replication-assume_sorted-and-windowing)
+  - [Multi-stream bookmark keys](#multi-stream-bookmark-keys)
+  - [Record list level and record level](#record-list-level-and-record-level)
+  - [unnest](#unnest)
+- [Authentication](#authentication)
+- [Custom http-headers](#custom-http-headers)
+- [Multiple streams](#multiple-streams)
+- [State](#state)
+- [Raw output mode](#raw-output-mode)
+- [Schema validation and cleanups](#schema-validation-and-cleanups)
+- [About this project](#about-this-project)
 
 ## What is it?
 
@@ -13,41 +36,36 @@ data following the [Singer spec](https://github.com/singer-io/getting-started).
 
 This tap:
 
-- Pulls JSON records from Rest API
-- Automatically infers the schema and generate JSON-schema and Singer catalog
-  file.
-- Incrementally pulls data based on the input state. (singer.io bookmark specification)
+- Pulls JSON records from a REST API.
+- Automatically infers the schema and generates a JSON schema and a Singer catalog file.
+- Incrementally pulls data based on the input state (the singer.io bookmark specification).
 
-The stdout from this program is intended by consumed by singer.io target program as:
+The stdout of this program is intended to be consumed by a singer.io target:
 
 ```
 tap-rest-api | target-csv
 ```
 
-## How to use it
-
-Install:
+## Install
 
 ```
 pip install tap-rest-api
 ```
 
-The following example is created using [USGS Earthquake Events data](https://earthquake.usgs.gov/fdsnws/event/1/).
+## Quick start (USGS example)
+
+The following example uses [USGS Earthquake Events data](https://earthquake.usgs.gov/fdsnws/event/1/):
 
 `curl https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime=2014-01-01&endtime=2014-01-02&minmagnitude=1`
 
-```
+```json
 {
   "type": "FeatureCollection",
   "features": [
     {
       "geometry": {
         "type": "Point",
-        "coordinates": [
-          -116.7776667,
-          33.6633333,
-          11.008
-        ]
+        "coordinates": [-116.7776667, 33.6633333, 11.008]
       },
       "type": "Feature",
       "properties": {
@@ -58,41 +76,37 @@ The following example is created using [USGS Earthquake Events data](https://ear
         "nst": 39,
         "tz": -480,
         "title": "M 1.3 - 10km SSW of Idyllwild, CA",
-        ...
         "mag": 1.29,
-        ...
         "place": "10km SSW of Idyllwild, CA",
         "time": 1388620296020,
         "mmi": null
       },
       "id": "ci11408890"
-    },
-    ...
+    }
   ]
 }
 ```
-[examples/usgs/sample_records.json](https://raw.githubusercontent.com/anelendata/tap-rest-api/master/examples/usgs/sample_records.json)
+(see [examples/usgs/sample_records.json](https://raw.githubusercontent.com/anelendata/tap-rest-api/master/examples/usgs/sample_records.json))
 
-In the following steps, we will atempt to extract `properties` section of
-the record type `Feature` as Singer record.
+In the following steps, we will attempt to extract the `properties` section of
+each `Feature` record as a Singer record.
 
 ### Step 1: Default spec
 
-Anything defined here can be added to tap configuration file or to the
+Anything defined here can be added to the tap configuration file or passed as a
 command-line argument:
 
 - [default_spec.json](https://github.com/anelendata/tap-rest-api/blob/master/tap_rest_api/default_spec.json)
 
-### Step 2: [Optional] Create a custom spec for config file:
+### Step 2: [Optional] Create a custom spec for the config file
 
-If you would like to define more configuration variables, create a spec file.
-Here is an
-[example] (https://github.com/anelendata/tap-rest-api/blob/master/examples/usgs/custom_spec.json):
-```
+If you want to define more configuration variables, create a spec file. Here is an
+[example](https://github.com/anelendata/tap-rest-api/blob/master/examples/usgs/custom_spec.json):
+
+```json
 {
     "args": {
-        "min_magnitude":
-        {
+        "min_magnitude": {
             "type": "integer",
             "default": "0",
             "help": "Filter based on the minimum magnitude."
@@ -104,21 +118,20 @@ Here is an
 Anything you define here overwrites
 [default_spec.json](https://github.com/anelendata/tap-rest-api/blob/master/tap_rest_api/default_spec.json).
 
-### Step 3. Create Config file:
+### Step 3: Create the config file
 
-**Please note jsonpath specification is supported version 0.2.0 and later only.**
+Note the difference between the spec file and the config file: the spec file
+creates or alters the config *specs*, while the config file provides the *values*
+for the config variables. When a value is not specified in the config file, the
+default value defined in the spec file is used.
 
-Now create a cofnig file. Note the difference between spec file and config file.
-The role of spec file is to create or alter the config specs, and the role of
-the config file is to provide the values to the config variables. When a value
-is not specified in the config file, the default value defined in the spec
-file is used.
+**Note: the jsonpath specification is supported in version 0.2.0 and later only.**
 
 [Example](https://github.com/anelendata/tap-rest-api/tree/master/examples/usgs/config/tap_config.json):
 
-```
+```json
 {
-  "url":"https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime={start_datetime}&endtime={end_datetime}&minmagnitude={min_magnitude}&limit={items_per_page}&offset={current_offset}&eventtype=earthquake&orderby=time-asc",
+  "url": "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime={start_datetime}&endtime={end_datetime}&minmagnitude={min_magnitude}&limit={items_per_page}&offset={current_offset}&eventtype=earthquake&orderby=time-asc",
   "record_list_level": "features[*]",
   "timestamp_key": "properties.time",
   "schema": "earthquakes",
@@ -129,80 +142,117 @@ file is used.
 }
 ```
 
-Below are some key concepts in the configuration file.
+Below are some key concepts used in the configuration file.
 
 #### Parametric URL
 
-You can use `{<config_varable_name>}` notion to insert the value specified at the config to URL.
+Use the `{<config_variable_name>}` notation to insert a value from the config into
+the URL.
 
 In addition to the config variables listed in
 [default_spec.json](https://github.com/anelendata/tap-rest-api/blob/master/tap_rest_api/default_spec.json)
-and the custom spec file, the URL also can contain parameters from the following run-time variables:
+and the custom spec file, the URL can also contain these run-time variables:
 
-- current_offset: Offset by the number of records to skip
-- current_page: The current page if the endpoint supports paging
-- last_update: The last retrieved value of the column specified by index_key, timestamp_key, or datetime_key
-  (See next section)
+- `current_offset`: Offset by the number of records to skip.
+- `current_page`: The current page, if the endpoint supports paging (`current_page_one_base` for 1-based paging).
+- `last_update`: The last retrieved value of the field specified by `index_key`, `timestamp_key`, or `datetime_key` (see below).
+- `start_datetime` / `end_datetime`, `start_timestamp` / `end_timestamp`, `start_index` / `end_index`: The bounds of the range being replicated.
 
-#### timestamp_key, datetime_key, index_key
+#### Bookmark keys: `timestamp_key`, `datetime_key`, `index_key`
 
-If you want to use timestamp, datetime, index in the parameterized URL or
-want to use a field in those types as a bookmark, one of either timestamp_key,
-datetime_key, or index_key must be set to indicate which field in the record
-corresponds to the data type.
+If you want to use a timestamp, datetime, or index in the parameterized URL, or
+want to use a field of one of those types as a bookmark, set exactly one of
+`timestamp_key`, `datetime_key`, or `index_key` to indicate which field in the
+record corresponds to the data type:
 
-- timestamp_key: POSIX timestamp
-- datetime_key: ISO 8601 formatted datetime (it can be truncated to date and etc)
-  It works when the character between the date and time components is " " instead of "T".
-- index_key: A sequential index (integer or string)
+- `timestamp_key`: POSIX timestamp.
+- `datetime_key`: ISO 8601 formatted datetime (it can be truncated to a date, etc.).
+  It also works when the separator between the date and time components is a space (" ") instead of "T".
+- `index_key`: A sequential index (integer or string).
 
-In USGS example, the individual record contains the top level objects `properties`
-and `geometry`. The timestamp key is `time` defined under `properties`, so the config
-value `timestamp_key` is set as `properties.time`, following
+In the USGS example, each record contains the top-level objects `properties` and
+`geometry`. The timestamp key `time` lives under `properties`, so `timestamp_key`
+is set to `properties.time`, following the
 [jsonpath](https://goessner.net/articles/JsonPath/) specification.
 
-When you specify timestamp_key, datetime_key, or index_key in the config,
-you also need to set start_timestamp, start_datetime, or start_index in
-config or as a command-line argument.
+When you specify `timestamp_key`, `datetime_key`, or `index_key`, you must also
+set `start_timestamp`, `start_datetime`, or `start_index` (in the config or as a
+command-line argument) as the initial lower bound.
 
-Optionally, you can set end_timestamp, end_datetime, or end_index to indicate
-so the process stops once such threashold is encounterd, assuming the data
-is sorted by the field.
+Optionally set `end_timestamp`, `end_datetime`, or `end_index` as an upper bound.
+For human convenience, `start_datetime` / `end_datetime` are also consulted when
+`timestamp_key` is set but `start_timestamp` / `end_timestamp` are not. When the
+upper bound is not set, the datetime/timestamp end defaults to **UTC now**.
 
-For human convenience, start/end_datetime (more human readable) is also looked
-up when timestamp_key is set but start/end_timestamp is not set.
+#### Incremental replication: `assume_sorted` and windowing
 
+On each run the tap bookmarks the highest bookmark-field value it has written and,
+via the input [state](#state), resumes from there on the next run.
 
-#### Multi-streams: timestamp_keys, datetime_keys, index_keys
+**`assume_sorted`** (default `true`) tells the tap that the response is already
+sorted by the bookmark field, so it may stop as soon as it encounters a value past
+the end bound. If the API cannot guarantee that ordering — for example, it filters
+on one field but can only sort by another — set `assume_sorted: false` so the tap
+drains every page.
 
-These dictionary values are used when you want to specify different bookmark types for each stream.
+**Bounded time windows** (`window_size_seconds` / `window_size_hours`, *new in
+0.2.18*): for a `datetime` or `timestamp` bookmark, set one of these to replicate
+the range `[bookmark, end)` in contiguous, half-open time windows. The bookmark is
+checkpointed to a window's upper bound **only after that window has been completely
+drained**, so a run cut short by a timeout or error leaves the bookmark at the last
+completed window instead of leaping past records that were never fetched. This keeps
+the incremental safe even when `assume_sorted` is `false` and the API is not sorted
+by the bookmark field.
 
-```
+Requirements:
+
+- Use with a `datetime` or `timestamp` bookmark.
+- The URL must bound **both** ends of the bookmark field (`__gte`/`__lt`, or whatever
+  the API uses for `{start_datetime}` and `{end_datetime}`).
+
+```json
 {
-...
+  "assume_sorted": false,
+  "window_size_hours": 6,
+  "url": ".../items?page={current_page_one_base}&modified__gte={start_datetime}&modified__lt={end_datetime}"
+}
+```
+
+When `window_size_*` is unset, the tap issues a single open-ended request (the
+original behavior).
+
+#### Multi-stream bookmark keys
+
+`timestamp_keys`, `datetime_keys`, and `index_keys` (plural) are dictionaries used
+when you want a different bookmark type per stream, keyed by stream ID:
+
+```json
+{
   "datetime_keys": {
     "some_stream": "modified_at"
   }
+}
 ```
+
+See [Multiple streams](#multiple-streams) for the full multi-stream setup.
 
 #### Record list level and record level
 
-- record_list_level:
-  Some API wraps a set of records under a property. Others responds a newline separated JSONs.
-  For the former, we need to specify a key so the tap can find the record level.
-  The USGS earthquake response is a single JSON object example. The records are listed under
-  features object. So the config value `record_list_level` is set as a jsonpath `features[*]`.
+- `record_list_level`:
+  Some APIs wrap the set of records under a property; others respond with
+  newline-separated JSON. For the former, specify a key so the tap can find the
+  record level. The USGS response is a single JSON object whose records are listed
+  under `features`, so `record_list_level` is set to the jsonpath `features[*]`.
 
-- record_level:
-  Under the individual record, there may be another layer of properties that separates
-  the data and meta data and we may only be interested in the former. If this is the case,
-  we can specify record_level. In USGS example, we can ignore `geometry` object and output
-  only the content of `properties` object. Set a jsonpath to `record_level` config value
-  to achieve this:
+- `record_level`:
+  Under an individual record there may be another layer of properties separating
+  the data from metadata, and you may only want the former. If so, specify
+  `record_level`. In the USGS example we can ignore the `geometry` object and output
+  only the contents of `properties` by setting `record_level` to a jsonpath:
 
-```
+```json
 {
-  "url":"https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime={start_datetime}&endtime={end_datetime}&minmagnitude={min_magnitude}&limit={items_per_page}&offset={current_offset}&eventtype=earthquake&orderby=time-asc",
+  "url": "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime={start_datetime}&endtime={end_datetime}&minmagnitude={min_magnitude}&limit={items_per_page}&offset={current_offset}&eventtype=earthquake&orderby=time-asc",
   "record_list_level": "features[*]",
   "record_level": "properties",
   "timestamp_key": "time",
@@ -216,60 +266,78 @@ These dictionary values are used when you want to specify different bookmark typ
 
 #### unnest
 
-When you want to flatten a nested record, the config below will grab the record["some_nested_col"]["modified_at"] and put it in record["modified_at"]:
+To flatten a nested record, the config below grabs
+`record["some_nested_col"]["modified_at"]` and puts it in `record["modified_at"]`:
 
-```
+```json
 {
-...
   "unnest": {
     "some_stream": [
       {
         "path": "$.some_nested_col.modified_at",
-        "target": "modified_at",
-    ],
-    ...
-  },
+        "target": "modified_at"
+      }
+    ]
+  }
+}
 ```
 
-Note: The schema and catalog must reflect the schema after unnesting. To aid this, infer_schema also does this transformation before determining the schema.
+Note: the schema and catalog must reflect the schema *after* unnesting. To help
+with this, `infer_schema` also applies this transformation before determining the
+schema.
 
-### Step 4. Create schema and catalog files
+### Step 4: Create the schema and catalog files
 
 ```
 $ tap-rest-api custom_spec.json --config config/tap_config.json --schema_dir ./schema --catalog_dir ./catalog --start_datetime="2020-08-06" --infer_schema
 ```
 
-The schema and catalog files are created under schema and catalog directories, respectively. By default --safe-schema-update=true, meaning that infer_schema modifies the exiting schema with append manner and does not overwrite the data types or sub-items in the struct of the existing fields. To overwrite everything, either remove the existing schema JSON files under the directory specified by --schema_dir or set --safe_schema_update=false.
+The schema and catalog files are created under the schema and catalog directories,
+respectively. By default `--safe-schema-update=true`, meaning `infer_schema`
+modifies the existing schema in an append manner and does not overwrite the data
+types or sub-items of existing fields. To overwrite everything, either remove the
+existing schema JSON files under `--schema_dir` or set `--safe_schema_update=false`.
 
+Notes:
 
-Note:
+- If no customization is needed, you can omit the spec file (`custom_spec.json`).
+- `start_datetime` and `end_datetime` are copied to `start_timestamp` and `end_timestamp`.
+- `end_timestamp` and `end_datetime` default to UTC now when not present in the config file or command-line argument.
+- When inferring the schema, you can use `--sample_dir <directory>` to read sample data from files instead of the API. Each file must be named `sample_dir/stream_name.json`, and its format must match the raw response from the REST API.
 
-- If no customization needed, you can omit the spec file (custom_spec.json)
-- `start_dateime` and `end_datetime` are copied to `start_timestamp` and `end_timestamp`.
-- `end_timestamp` and `end_datetime` are automatically set as UTC now if not present in the config file or command-line argument.
-- When inferring schema, you can also use `--sample_dir <directory>` option to read sample data from the file. The file must have the name sample_dir/stream_name.json and the format must match the raw response from the rest API.
-
-### Step 5. Run the tap
+### Step 5: Run the tap
 
 ```
 $ tap-rest-api ./custom_spec.json --config config/tap_config.json --start_datetime="2020-08-06" --catalog ./catalog/earthquakes.json
 ```
 
+## Configuration
+
+The reference for the configuration file is spread across the [Quick start](#quick-start-usgs-example)
+subsections above ([Parametric URL](#parametric-url),
+[bookmark keys](#bookmark-keys-timestamp_key-datetime_key-index_key),
+[incremental replication and windowing](#incremental-replication-assume_sorted-and-windowing),
+[record levels](#record-list-level-and-record-level), [unnest](#unnest)) and the
+sections below ([Authentication](#authentication),
+[Custom http-headers](#custom-http-headers), [Multiple streams](#multiple-streams),
+[Schema validation and cleanups](#schema-validation-and-cleanups)). The full list
+of options with their defaults is in
+[default_spec.json](https://github.com/anelendata/tap-rest-api/blob/master/tap_rest_api/default_spec.json).
+
 ## Authentication
 
-The example above does not require login. tap-rest-api currently supports
-basic auth. If this is needed add something like:
+The example above does not require login. tap-rest-api currently supports basic
+auth. If this is needed, add something like:
 
-```
+```json
 {
   "auth_method": "basic",
   "username": "my_username",
-  "password": "my_password",
-  ...
+  "password": "my_password"
 }
 ```
 
-Or add those at the commands line:
+Or add those on the command line:
 
 ```
 tap-rest-api config/custom_spec.json --config config/tap_config.json --schema_dir ./config/schema --catalog ./config/catalog/some_catalog.json --start_datetime="2020-08-06" --username my_username --password my_password --auth_method basic
@@ -277,48 +345,46 @@ tap-rest-api config/custom_spec.json --config config/tap_config.json --schema_di
 
 ## Custom http-headers
 
-In addition to the authentication method, you can specify the http header
-in config file:
+In addition to the authentication method, you can specify the http headers in the
+config file:
 
-Example:
-
-```
-...
-"http_headers":
-    {
-      "User-Agent": "Mozilla/5.0 (Macintosh; scitylana.singer.io) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36",
-      "Content-type": "application/json",
-      "Authorization": "Bearer <some-key>"
-    },
-...
+```json
+{
+  "http_headers": {
+    "User-Agent": "Mozilla/5.0 (Macintosh; scitylana.singer.io) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36",
+    "Content-type": "application/json",
+    "Authorization": "Bearer <some-key>"
+  }
+}
 ```
 
 Here is the default value:
-```
+
+```json
 {
   "User-Agent": "Mozilla/5.0 (Macintosh; scitylana.singer.io) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36",
   "Content-type": "application/json"
 }
 ```
 
-When you define http_headers config value, the default value is nullified.
-So you should redefine "User-Agent" and "Content-type" when you need them.
+When you define the `http_headers` config value, the default value is nullified,
+so you should redefine `User-Agent` and `Content-type` when you need them.
 
 ## Multiple streams
 
-tap-rest-api suports settings for multiple streams.
+tap-rest-api supports settings for multiple streams.
 
-- `url` is set as string for default value.
-- `urls` is a dictionary to overwrite the default `url` for the specified stream ID given as the dictionary key
-- `{stream}` can be used as parameter in URL.
-- `timestamp_keys`, `datetime_keys`, `index_keys` can be set as dictionary. If a stream ID exists in the dictionary key in one of the items, it will be used. If not, the key defaults to a string defined one with priotiry (timestamp_key > datetime_key > index_key.
-- `datetime_key`, `timestamp_key`, and `index_key` are set as string and the default bookmark keys.
-- Active streams must be defined as a comma separated stream IDs either in the config file or in the command `--stream <streams>`
-- Streams must be registered in catalog file with `selected: true` ([example](https://github.com/anelendata/tap-rest-api/blob/master/examples/usgs/catalog/earthquakes.json))
+- `url` is a string, used as the default.
+- `urls` is a dictionary that overrides the default `url` for the stream ID given as the dictionary key.
+- `{stream}` can be used as a parameter in the URL.
+- `timestamp_keys`, `datetime_keys`, `index_keys` can be set as dictionaries. If a stream ID exists as a key in one of them, it is used; otherwise the key falls back to the string-valued `timestamp_key` > `datetime_key` > `index_key` (in that priority).
+- `datetime_key`, `timestamp_key`, and `index_key` are set as strings and are the default bookmark keys.
+- Active streams must be defined as comma-separated stream IDs, either in the config file or via `--stream <streams>`.
+- Streams must be registered in the catalog file with `selected: true` ([example](https://github.com/anelendata/tap-rest-api/blob/master/examples/usgs/catalog/earthquakes.json)).
 
-Here is an example for [Chargify API](https://developers.chargify.com/docs/api-docs)
+Here is an example for the [Chargify API](https://developers.chargify.com/docs/api-docs):
 
-```
+```json
 {
   "url": "https://{{ subdomain }}.chargify.com/{stream}.json?direction=asc&per_page={items_per_page}&page={current_page_one_base}&date_field={datetime_key}&start_datetime={start_datetime}",
   "urls": {
@@ -379,44 +445,43 @@ Here is an example for [Chargify API](https://developers.chargify.com/docs/api-d
 ## State
 
 This tap emits [state](https://github.com/singer-io/getting-started/blob/master/docs/CONFIG_AND_STATE.md#state-file).
-The command also takes a state file input with `--state <file-name>` option.
-The tap itself does not output a state file. It anticipate the target program or a downstream process to fianlize the state safetly and produce a state file.
+The command also takes a state file as input with the `--state <file-name>` option.
+The tap itself does not write a state file; it expects the target program or a
+downstream process to finalize the state safely and produce the state file.
 
 ## Raw output mode
 
-If you want to use this tap outside Singer framework, set `--raw` in the
-commandline argument. Then the process write out the records as
-newline-separated JSON.
+If you want to use this tap outside the Singer framework, set `--raw` on the
+command line. The process then writes out the records as newline-separated JSON.
 
-A use case for this mode is when you expect the schema to change or inconsistent
-and you rather want to extract and clean up post-loading.
+A use case for this mode is when you expect the schema to change or be inconsistent
+and you would rather extract and clean up after loading.
 ([Example](https://articles.anelen.co/elt-google-cloud-storage-bigquery/))
 
 ## Schema validation and cleanups
 
-- on_invalid_property: Behavior when schema validation fails.
-  - "raise": Raise exception
-  - "null": Impute with null
-  - "force" (default): Keep the record value as is (string). This may fail in the singer target.
-- drop_unknown_properties: If true, record will exclude unknown (sub-)properties before it's being written to stdout. Default is false.
+- `on_invalid_property`: Behavior when schema validation fails.
+  - `"raise"`: Raise an exception.
+  - `"null"`: Impute with null.
+  - `"force"` (default): Keep the record value as-is (string). This may fail in the Singer target.
+- `drop_unknown_properties`: If true, records exclude unknown (sub-)properties before being written to stdout. Default is false.
 
-Config example to add them:
-```
+Config example:
+
+```json
 {
-...
   "on_invalid_property": "force",
-  "drop_unknown_properties": true,
-...
+  "drop_unknown_properties": true
 }
 ```
 
 # About this project
 
-This project is developed by 
-ANELEN and friends. Please check out the ANELEN's
-[open innovation philosophy and other projects](https://anelen.co/open-source.html)
+This project is developed by ANELEN and friends. Please check out ANELEN's
+[open innovation philosophy and other projects](https://anelen.co/open-source.html).
 
 ![ANELEN](https://avatars.githubusercontent.com/u/13533307?s=400&u=a0d24a7330d55ce6db695c5572faf8f490c63898&v=4)
+
 ---
 
 Copyright &copy; 2020~ Anelen Co., LLC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tap-rest-api"
-version = "0.2.17"
+version = "0.2.18"
 description = "Singer.io tap for extracting data from any REST API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tap_rest_api/default_spec.json
+++ b/tap_rest_api/default_spec.json
@@ -191,6 +191,18 @@
             "default": null,
             "help": "If set, stop the sync after global_timeout seconds."
         },
+        "window_size_seconds":
+        {
+            "type": "integer",
+            "default": null,
+            "help": "If set (with a datetime/timestamp bookmark), replicate in contiguous half-open time windows of this size instead of one open-ended request. The bookmark is only advanced (checkpointed) after a window fully drains, so a timeout cannot leapfrog past unfetched records. Requires the URL to bound both ends of the bookmark field (e.g. ...__gte={start_datetime}&...__lt={end_datetime})."
+        },
+        "window_size_hours":
+        {
+            "type": "number",
+            "default": null,
+            "help": "Convenience alternative to window_size_seconds, expressed in hours."
+        },
         "max_page":
         {
             "type": "integer",

--- a/tap_rest_api/helper.py
+++ b/tap_rest_api/helper.py
@@ -367,6 +367,57 @@ def get_init_endpoint_params(config, state, tap_stream_id):
     return params
 
 
+def iter_window_bounds(start_epoch, end_epoch, window_seconds):
+    """Yield contiguous, half-open [w_start, w_end) windows (in epoch seconds)
+    covering [start_epoch, end_epoch].
+
+    Windows are contiguous (each w_end is the next w_start) and the final window's
+    end is clamped to end_epoch, so the union is exactly [start_epoch, end_epoch]
+    with no gaps and no overlaps. Yields nothing when start_epoch >= end_epoch.
+    """
+    if not window_seconds or window_seconds <= 0:
+        raise ValueError("window_size must be a positive number of seconds")
+    w_start = float(start_epoch)
+    end_epoch = float(end_epoch)
+    while w_start < end_epoch:
+        w_end = min(w_start + window_seconds, end_epoch)
+        yield w_start, w_end
+        w_start = w_end
+
+
+def get_windowed_endpoint_params(config, tap_stream_id, w_start_epoch, w_end_epoch):
+    """Like get_init_endpoint_params, but for a single [w_start, w_end) window given
+    as epoch seconds. Windowing requires a time-ordered bookmark, so only datetime
+    and timestamp bookmark types are supported.
+    """
+    bookmark_type, bookmark_key = get_bookmark_type_and_key(config, tap_stream_id)
+    params = dict(config)
+    start_datetime = format_datetime(config, datetime.datetime.fromtimestamp(w_start_epoch))
+    end_datetime = format_datetime(config, datetime.datetime.fromtimestamp(w_end_epoch))
+    params.update({
+        "start_timestamp": w_start_epoch,
+        "end_timestamp": w_end_epoch,
+        "start_datetime": start_datetime,
+        "end_datetime": end_datetime,
+        "start_date": start_datetime[0:10],
+        "end_date": end_datetime[0:10],
+    })
+    if bookmark_type == "timestamp":
+        params["timestamp_key"] = bookmark_key
+    elif bookmark_type == "datetime":
+        params["datetime_key"] = bookmark_key
+    else:
+        raise ValueError("window_size requires a datetime or timestamp bookmark")
+
+    params.update({
+        "stream": tap_stream_id,
+        "current_page": config.get("page_start", 0),
+        "current_offset": config.get("offset_start", 0),
+        "last_update": w_start_epoch if bookmark_type == "timestamp" else start_datetime,
+    })
+    return params
+
+
 def get_http_headers(config=None):
     if not config or not config.get("http_headers"):
         return {"User-Agent": USER_AGENT,

--- a/tap_rest_api/helper.py
+++ b/tap_rest_api/helper.py
@@ -123,9 +123,9 @@ def get_bookmark_type_and_key(config, stream):
     dt_keys = config.get("datetime_keys")
     i_keys = config.get("index_keys")
 
-    assert(dt_key is None or isinstance(dt_key, str), "config.datetime_key must be a string")
-    assert(ts_key is None or isinstance(ts_key, str), "config.timestamp_key must be a string")
-    assert(i_key is None or isinstance(i_key, str), "config.index_key must be a string")
+    assert dt_key is None or isinstance(dt_key, str), "config.datetime_key must be a string"
+    assert ts_key is None or isinstance(ts_key, str), "config.timestamp_key must be a string"
+    assert i_key is None or isinstance(i_key, str), "config.index_key must be a string"
 
     if isinstance(ts_keys, dict) and ts_keys.get(stream):
         return "timestamp", ts_keys.get(stream)
@@ -237,11 +237,17 @@ def get_end(config, tap_stream_id):
                 end_from_config = dateutil.parser.parse(
                     config["end_datetime"]).timestamp()
             else:
-                end_from_config = datetime.datetime.now().timestamp()
+                # Bookmarks/records are UTC; use an explicit UTC "now" so the end
+                # bound does not skew on a non-UTC host.
+                end_from_config = datetime.datetime.now(
+                    datetime.timezone.utc).timestamp()
     elif bookmark_type == "datetime":
         end_from_config = config.get("end_datetime")
         if not end_from_config:
-            end_from_config = format_datetime(config, datetime.datetime.now())
+            # utcnow(), not now(): the datetime bookmark and the records it is
+            # compared against are UTC. Local now() would offset the upper bound
+            # by the host's timezone (e.g. gate out the last N hours of data).
+            end_from_config = format_datetime(config, datetime.datetime.utcnow())
     elif bookmark_type == "index":
         end_from_config = config.get("end_index")
     return end_from_config
@@ -392,8 +398,12 @@ def get_windowed_endpoint_params(config, tap_stream_id, w_start_epoch, w_end_epo
     """
     bookmark_type, bookmark_key = get_bookmark_type_and_key(config, tap_stream_id)
     params = dict(config)
-    start_datetime = format_datetime(config, datetime.datetime.fromtimestamp(w_start_epoch))
-    end_datetime = format_datetime(config, datetime.datetime.fromtimestamp(w_end_epoch))
+    # utcfromtimestamp (not fromtimestamp): the window epochs are UTC, and the
+    # formatted bounds go into the URL filter and the per-record write-gate, both
+    # of which compare against UTC record timestamps. Local conversion would skew
+    # both on a non-UTC host.
+    start_datetime = format_datetime(config, datetime.datetime.utcfromtimestamp(w_start_epoch))
+    end_datetime = format_datetime(config, datetime.datetime.utcfromtimestamp(w_end_epoch))
     params.update({
         "start_timestamp": w_start_epoch,
         "end_timestamp": w_end_epoch,

--- a/tap_rest_api/main.py
+++ b/tap_rest_api/main.py
@@ -42,6 +42,7 @@ TYPES = {
     "string": str,
     "datetime": str,
     "integer": int,
+    "number": float,
     "boolean": str2bool
     }
 

--- a/tap_rest_api/schema.py
+++ b/tap_rest_api/schema.py
@@ -28,9 +28,9 @@ class Schema(object):
     def validate(record, schema):
         try:
             jsonschema.validate(record, schema)
-        except jsonschema.exceptions.ValidationError:
-            return False
-        return True
+        except jsonschema.exceptions.ValidationError as e:
+            return False, str(e)
+        return True, None
 
     @staticmethod
     def filter_record(

--- a/tap_rest_api/sync.py
+++ b/tap_rest_api/sync.py
@@ -189,8 +189,9 @@ class Sync(object):
                                 drop_unknown_properties=drop_unknown_properties,
                                 )
 
-                    if not Schema.validate(record, schema):
-                        LOGGER.debug("Skipping the schema invalidated row %s" % record)
+                    valid, reason = Schema.validate(record, schema)
+                    if not valid:
+                        LOGGER.warning(f"Skipping the schema invalidated (Reason: {reason}) row:\n  {json.dumps(record)}\n\n")
                         continue
 
                     # It's important to compare the record before adding

--- a/tap_rest_api/sync.py
+++ b/tap_rest_api/sync.py
@@ -25,6 +25,10 @@ from .helper import (
     get_digest_from_record,
     unnest,
     EXTRACT_TIMESTAMP,
+    format_datetime,
+    parse_datetime_tz,
+    get_windowed_endpoint_params,
+    iter_window_bounds,
 )
 from .schema import Schema
 
@@ -121,158 +125,248 @@ class Sync(object):
         if last_record_extracted:
             prev_written_record = json.loads(last_record_extracted)
 
-        # First writ out the schema
+        # First write out the schema
         if raw_output is False:
             singer.write_schema(tap_stream_id, schema, key_properties)
 
+        window_seconds = self.config.get("window_size_seconds")
+        if not window_seconds and self.config.get("window_size_hours"):
+            window_seconds = float(self.config["window_size_hours"]) * 3600.0
+
         # Fetch and iterate over to write the records
         with metrics.record_counter(tap_stream_id) as counter:
-            while True:
-                if (self.started_at and global_timeout and
-                    datetime.datetime.now() - self.started_at >= datetime.timedelta(seconds=global_timeout)):
-                    LOGGER.warning(f"Timeout {global_timeout} reached. Not doing further sync.")
-                    break
+            if (window_seconds and bookmark_type in ("datetime", "timestamp")
+                    and start is not None and end is not None):
+                current_state = self._sync_windowed(
+                    current_state, tap_stream_id, schema, start, end, bookmark_type,
+                    window_seconds, prev_written_record, counter, raw_output)
+            else:
+                completed, last_update, prev_written_record = self._drain_pages(
+                    tap_stream_id, params, schema, end, last_update,
+                    prev_written_record, counter, raw_output)
+                # Not windowing: advance the bookmark to the max value seen (legacy behavior).
+                if bookmark_type == "timestamp" and len(str(int(last_update))) == 10:
+                    last_update = int(last_update * 1000)
+                current_state = singer.write_bookmark(
+                    current_state, tap_stream_id, "last_update", last_update)
+                if prev_written_record:
+                    current_state = singer.write_bookmark(
+                        current_state, tap_stream_id, "last_record_extracted",
+                        json.dumps(prev_written_record))
+                if raw_output is False:
+                    singer.write_state(current_state)
 
-                params.update({"current_page": page_number})
-                params.update({"current_page_one_base": page_number + 1})
-                params.update({"current_offset": offset_number})
-                params.update({"last_update": last_update})
+        return current_state
 
-                url = self.config.get("urls", {}).get(tap_stream_id, self.config["url"])
-                endpoint = get_endpoint(url, tap_stream_id, params)
-                LOGGER.info("GET %s", endpoint)
+    def _drain_pages(self, tap_stream_id, params, schema, end, last_update,
+                     prev_written_record, counter, raw_output):
+        """Paginate a single query (one window, or the whole range when not windowing)
+        to exhaustion, writing every record fetched.
 
-                rows = []
+        Returns (completed, last_update, prev_written_record). ``completed`` is True
+        only when the API signalled the natural end of data (a short/last page), or,
+        with assume_sorted, when the sort passed ``end``. It is False when the run was
+        cut short by global_timeout or max_page -- in which case the caller must NOT
+        advance the bookmark past records that were never fetched.
+        """
+        max_page = self.config.get("max_page")
+        global_timeout = self.config.get("global_timeout")
+        auth_method = self.config.get("auth_method", "basic")
+        assume_sorted = self.config.get("assume_sorted", True)
+        filter_by_schema = self.config.get("filter_by_schema", True)
+        on_invalid_property = self.config.get("on_invalid_property", "force")
+        drop_unknown_properties = self.config.get("drop_unknown_properties", False)
+        headers = get_http_headers(self.config)
+
+        page_number = params.get("current_page", 0)
+        offset_number = params.get("current_offset", 0)
+        next_last_update = None
+        completed = False
+
+        while True:
+            if (self.started_at and global_timeout and
+                datetime.datetime.now() - self.started_at >= datetime.timedelta(seconds=global_timeout)):
+                LOGGER.warning(f"Timeout {global_timeout} reached. Not doing further sync.")
+                break
+
+            params.update({"current_page": page_number})
+            params.update({"current_page_one_base": page_number + 1})
+            params.update({"current_offset": offset_number})
+            params.update({"last_update": last_update})
+
+            url = self.config.get("urls", {}).get(tap_stream_id, self.config["url"])
+            endpoint = get_endpoint(url, tap_stream_id, params)
+            LOGGER.info("GET %s", endpoint)
+
+            rows = []
+            try:
+                rows = generate_request(tap_stream_id, endpoint, auth_method,
+                                        headers,
+                                        self.config.get("username"),
+                                        self.config.get("password"))
+            except Exception as e:
+                if page_number == self.config.get("page_start", 0):
+                    raise
+                LOGGER.error(f"Endpoint responded with an error: {str(e)}")
+
+            # In case the record is not at the root level
+            record_list_level = self.config.get("record_list_level")
+            if isinstance(record_list_level, dict):
+                record_list_level = record_list_level.get(tap_stream_id)
+            record_level = self.config.get("record_level")
+            if isinstance(record_level, dict):
+                record_level = record_level.get(tap_stream_id)
+
+            rows = get_record_list(rows, record_list_level)
+            if not isinstance(rows, list):
+                rows = [rows]
+
+            LOGGER.info("Current page %d" % page_number)
+            LOGGER.info("Current offset %d" % offset_number)
+
+            LOGGER.debug("    Row process started.")
+            row_process_started_at = datetime.datetime.now()
+            for row in rows:
+                record = get_record(row, record_level)
+
+                unnest_config = self.config.get("unnest", {})
+                if unnest_config is None:
+                    unnest_config = {}
+                unnest_cols = unnest_config.get(tap_stream_id, [])
+                for u in unnest_cols:
+                    record = unnest(record, u["path"], u["target"])
+
+                if filter_by_schema:
+                    record = Schema.filter_record(
+                            record,
+                            schema,
+                            on_invalid_property=on_invalid_property,
+                            drop_unknown_properties=drop_unknown_properties,
+                            )
+
+                valid, reason = Schema.validate(record, schema)
+                if not valid:
+                    LOGGER.warning(f"Skipping the schema invalidated (Reason: {reason}) row:\n  {json.dumps(record)}\n\n")
+                    continue
+
+                # It's important to compare the record before adding EXTRACT_TIMESTAMP
+                digest = get_digest_from_record(record)
+                digest_dict = {"digest": digest}
+                if (prev_written_record == record or
+                        prev_written_record == digest_dict):
+                    LOGGER.info(
+                        "Skipping the duplicated row with "
+                        f"digest {digest}"
+                    )
+                    continue
+
+                if EXTRACT_TIMESTAMP in schema["properties"].keys():
+                    extract_tstamp = datetime.datetime.utcnow()
+                    extract_tstamp = extract_tstamp.replace(
+                        tzinfo=datetime.timezone.utc)
+                    record[EXTRACT_TIMESTAMP] = extract_tstamp.isoformat()
+
                 try:
-                    rows = generate_request(tap_stream_id, endpoint, auth_method,
-                                            headers,
-                                            self.config.get("username"),
-                                            self.config.get("password"))
+                    next_last_update = get_last_update(self.config, tap_stream_id, record, last_update)
                 except Exception as e:
-                    if page_number == self.config.get("page_start", 0):
-                        raise
-                    LOGGER.error(f"Endpoint responded with an error: {str(e)}")
+                    LOGGER.error(f"Error with the record:\n    {row}\n    message: {e}")
+                    raise
 
-                # In case the record is not at the root level
-                record_list_level = self.config.get("record_list_level")
-                if isinstance(record_list_level, dict):
-                    record_list_level = record_list_level.get(tap_stream_id)
-                record_level = self.config.get("record_level")
-                if isinstance(record_level, dict):
-                    record_level = record_level.get(tap_stream_id)
+                if not end or next_last_update < end:
+                    if raw_output:
+                        sys.stdout.write(json.dumps(record) + "\n")
+                    else:
+                        singer.write_record(tap_stream_id, record)
 
-                rows = get_record_list(rows, record_list_level)
-                if not isinstance(rows, list):
-                    rows = [rows]
+                    counter.increment()  # Increment only when we write
+                    last_update = next_last_update
 
-                LOGGER.info("Current page %d" % page_number)
-                LOGGER.info("Current offset %d" % offset_number)
-
-                LOGGER.debug("    Row process started.")
-                row_process_started_at = datetime.datetime.now()
-                for row in rows:
-                    record = get_record(row, record_level)
-
-                    unnest_config = self.config.get("unnest", {})
-                    # Why self.config.get("unnest", {}) is returning NoneType instead of {}???
-                    if unnest_config is None:
-                        unnest_config = {}
-                    unnest_cols = unnest_config.get(tap_stream_id, [])
-                    for u in unnest_cols:
-                        record = unnest(record, u["path"], u["target"])
-
-                    if filter_by_schema:
-                        record = Schema.filter_record(
-                                record,
-                                schema,
-                                on_invalid_property=on_invalid_property,
-                                drop_unknown_properties=drop_unknown_properties,
-                                )
-
-                    valid, reason = Schema.validate(record, schema)
-                    if not valid:
-                        LOGGER.warning(f"Skipping the schema invalidated (Reason: {reason}) row:\n  {json.dumps(record)}\n\n")
-                        continue
-
-                    # It's important to compare the record before adding
-                    # EXTRACT_TIMESTAMP
+                    # prev_written_record may be persisted for the next run.
+                    # EXTRACT_TIMESTAMP will be different. So popping it out before storing.
+                    record.pop(EXTRACT_TIMESTAMP)
                     digest = get_digest_from_record(record)
-                    digest_dict = {"digest": digest}
-                    # backward compatibility
-                    if (prev_written_record == record or
-                            prev_written_record == digest_dict):
-                        LOGGER.info(
-                            "Skipping the duplicated row with "
-                            f"digest {digest}"
-                        )
-                        continue
+                    prev_written_record = {"digest": digest}
 
-                    if EXTRACT_TIMESTAMP in schema["properties"].keys():
-                        extract_tstamp = datetime.datetime.utcnow()
-                        extract_tstamp = extract_tstamp.replace(
-                            tzinfo=datetime.timezone.utc)
-                        record[EXTRACT_TIMESTAMP] = extract_tstamp.isoformat()
+            row_process_sec = datetime.datetime.now() - row_process_started_at
+            LOGGER.debug(f"    row process completed in {row_process_sec} seconds.")
 
-                    try:
-                        next_last_update = get_last_update(self.config, tap_stream_id, record, last_update)
-                    except Exception as e:
-                        LOGGER.error(f"Error with the record:\n    {row}\n    message: {e}")
-                        raise
+            # Exit conditions
+            if len(rows) < self.config["items_per_page"]:
+                LOGGER.info(("Response is less than set item per page (%d)." +
+                            "Finishing the extraction") %
+                            self.config["items_per_page"])
+                completed = True
+                break
+            if max_page and page_number + 1 >= max_page:
+                LOGGER.info("Max page %d reached. Finishing the extraction." % max_page)
+                break
+            if assume_sorted and end and (next_last_update and next_last_update >= end):
+                LOGGER.info(("Record greater than %s and assume_sorted is" +
+                            " set. Finishing the extraction.") % end)
+                completed = True
+                break
 
-                    if not end or next_last_update < end:
-                        if raw_output:
-                            sys.stdout.write(json.dumps(record) + "\n")
-                        else:
-                            singer.write_record(tap_stream_id, record)
+            page_number += 1
+            offset_number += len(rows)
 
-                        counter.increment()  # Increment only when we write
-                        last_update = next_last_update
+        return completed, last_update, prev_written_record
 
-                        # prev_written_record may be persisted for the next run.
-                        # EXTRACT_TIMESTAMP will be different. So popping it out
-                        # before storing.
-                        record.pop(EXTRACT_TIMESTAMP)
-                        digest = get_digest_from_record(record)
-                        prev_written_record = {"digest": digest}
+    def _sync_windowed(self, current_state, tap_stream_id, schema, start, end,
+                       bookmark_type, window_seconds, prev_written_record,
+                       counter, raw_output):
+        """Replicate in contiguous, fully-drained time windows.
 
-                row_process_sec = datetime.datetime.now() - row_process_started_at
-                LOGGER.debug(f"    row process completed in {row_process_sec} seconds.")
+        The bookmark is checkpointed to a window's (exclusive) upper bound only after
+        that window is completely drained. A window cut short by a timeout leaves the
+        bookmark at the last completed boundary, so the next run resumes there -- no
+        leapfrog past unfetched records, no silent loss. Requires the URL to bound
+        both ends of the bookmark field, e.g.
+        ...__gte={start_datetime}&...__lt={end_datetime}.
+        """
+        if bookmark_type == "timestamp":
+            start_epoch = get_float_timestamp(start)
+            end_epoch = get_float_timestamp(end)
+        else:  # datetime
+            start_epoch = parse_datetime_tz(start).timestamp()
+            end_epoch = parse_datetime_tz(end).timestamp()
 
-                # Exit conditions
-                if len(rows) < self.config["items_per_page"]:
-                    LOGGER.info(("Response is less than set item per page (%d)." +
-                                "Finishing the extraction") %
-                                self.config["items_per_page"])
-                    break
-                if max_page and page_number + 1 >= max_page:
-                    LOGGER.info("Max page %d reached. Finishing the extraction." % max_page)
-                    break
-                if assume_sorted and end and (next_last_update and next_last_update >= end):
-                    LOGGER.info(("Record greater than %s and assume_sorted is" +
-                                " set. Finishing the extraction.") % end)
-                    break
+        for w_start, w_end in iter_window_bounds(start_epoch, end_epoch, window_seconds):
+            params = get_windowed_endpoint_params(self.config, tap_stream_id, w_start, w_end)
+            # Exclusive upper bound in the bookmark's native format, used both as the
+            # checkpoint value and as the per-record write-gate (keeps windows half-open
+            # even if the URL uses an inclusive __lte).
+            if bookmark_type == "timestamp":
+                gate_end = params["end_timestamp"]
+                checkpoint = params["end_timestamp"]
+            else:
+                gate_end = params["end_datetime"]
+                checkpoint = params["end_datetime"]
 
-                page_number +=1
-                offset_number += len(rows)
+            LOGGER.info("Window %s [%s, %s)" %
+                        (tap_stream_id, params["start_datetime"], params["end_datetime"]))
 
-        # If timestamp_key is not integerized, do so at millisecond level
-        if bookmark_type == "timestamp" and len(str(int(last_update))) == 10:
-            last_update = int(last_update * 1000)
+            completed, _last_update, prev_written_record = self._drain_pages(
+                tap_stream_id, params, schema, gate_end, params["last_update"],
+                prev_written_record, counter, raw_output)
 
-        current_state = singer.write_bookmark(
-            current_state,
-            tap_stream_id,
-            "last_update",
-            last_update,
-        )
+            if not completed:
+                LOGGER.warning(
+                    "Window ending %s did not fully drain (timeout/max_page). Leaving "
+                    "the bookmark at the last completed window and stopping so the next "
+                    "run resumes here." % checkpoint)
+                break
 
-        if prev_written_record:
-            current_state = singer.write_bookmark(current_state, tap_stream_id,
-                                        "last_record_extracted",
-                                        json.dumps(prev_written_record))
-
-        if raw_output == False:
-            singer.write_state(current_state)
+            if bookmark_type == "timestamp" and len(str(int(checkpoint))) == 10:
+                checkpoint = int(checkpoint * 1000)
+            current_state = singer.write_bookmark(
+                current_state, tap_stream_id, "last_update", checkpoint)
+            if prev_written_record:
+                current_state = singer.write_bookmark(
+                    current_state, tap_stream_id, "last_record_extracted",
+                    json.dumps(prev_written_record))
+            if raw_output is False:
+                singer.write_state(current_state)
+            LOGGER.info("Checkpoint: window drained; bookmark advanced to %s" % checkpoint)
 
         return current_state
 

--- a/tap_rest_api/sync.py
+++ b/tap_rest_api/sync.py
@@ -283,7 +283,9 @@ class Sync(object):
 
                     # prev_written_record may be persisted for the next run.
                     # EXTRACT_TIMESTAMP will be different. So popping it out before storing.
-                    record.pop(EXTRACT_TIMESTAMP)
+                    # It is only added when the schema declares it, so pop with a
+                    # default to avoid KeyError when the schema omits it.
+                    record.pop(EXTRACT_TIMESTAMP, None)
                     digest = get_digest_from_record(record)
                     prev_written_record = {"digest": digest}
 

--- a/tests/unit/test_fixes.py
+++ b/tests/unit/test_fixes.py
@@ -1,0 +1,111 @@
+"""Regression tests for anelendata/tap-rest-api issues #38, #39, #40."""
+import datetime
+
+import pytest
+
+
+# --- #39: assert(cond, "msg") always passed (tuple truthiness) ----------------
+
+def test_bookmark_key_type_assert_fires_on_non_string():
+    """Non-string *_key must now raise (the parenthesized asserts were dead)."""
+    import tap_rest_api.helper as H
+    with pytest.raises(AssertionError):
+        H.get_bookmark_type_and_key({"datetime_key": 123}, "orders")
+    with pytest.raises(AssertionError):
+        H.get_bookmark_type_and_key({"timestamp_key": ["x"]}, "orders")
+    with pytest.raises(AssertionError):
+        H.get_bookmark_type_and_key({"index_key": 5}, "orders")
+
+
+def test_bookmark_key_type_assert_allows_valid():
+    import tap_rest_api.helper as H
+    assert H.get_bookmark_type_and_key(
+        {"datetime_keys": {"orders": "modified"}}, "orders") == ("datetime", "modified")
+    assert H.get_bookmark_type_and_key(
+        {"datetime_key": "modified", "datetime_keys": {"orders": "modified"}},
+        "orders") == ("datetime", "modified")
+
+
+# --- #38: get_end() must use UTC "now", not naive local now() -----------------
+
+def test_get_end_datetime_uses_utcnow(monkeypatch):
+    import tap_rest_api.helper as H
+    fixed_utc = datetime.datetime(2026, 1, 1, 20, 0, 0)
+    fixed_local = datetime.datetime(2026, 1, 1, 12, 0, 0)  # a non-UTC host, 8h behind
+
+    class FakeDT(datetime.datetime):
+        @classmethod
+        def utcnow(cls):
+            return fixed_utc
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_local
+
+    monkeypatch.setattr(H.datetime, "datetime", FakeDT)
+    cfg = {"datetime_keys": {"orders": "modified"},
+           "url_param_datetime_format": "%Y-%m-%dT%H:%M:%S.%f"}
+    end = H.get_end(cfg, "orders")
+    assert end == "2026-01-01T20:00:00.000000"          # from utcnow()
+    assert end != "2026-01-01T12:00:00.000000"          # not local now()
+
+
+def test_get_end_timestamp_uses_utc_aware_now(monkeypatch):
+    import tap_rest_api.helper as H
+    fixed = datetime.datetime(2026, 1, 1, 20, 0, 0, tzinfo=datetime.timezone.utc)
+
+    class FakeDT(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            # the fix must pass an explicit tz (UTC), not call a naive now()
+            assert tz is not None
+            return fixed
+
+    monkeypatch.setattr(H.datetime, "datetime", FakeDT)
+    cfg = {"timestamp_keys": {"orders": "ts"}}
+    assert H.get_end(cfg, "orders") == fixed.timestamp()
+
+
+# --- #40: unconditional record.pop(EXTRACT_TIMESTAMP) KeyError'd -------------
+
+def test_drain_pages_no_keyerror_when_schema_omits_extract_timestamp(monkeypatch):
+    """A schema without _sdc_extracted_at must not crash on the post-write pop."""
+    import tap_rest_api.sync as S
+    import tap_rest_api.schema as SC
+
+    def fake_request(stream, endpoint, *a, **k):
+        return [{"id": 1, "modified": "2026-01-01T00:00:00.000000"}] \
+            if "page=1" in endpoint else []
+
+    written = []
+    monkeypatch.setattr(S, "generate_request", fake_request)
+    monkeypatch.setattr(SC.Schema, "validate", staticmethod(lambda rec, sch: (True, None)))
+    monkeypatch.setattr(S.singer, "write_record", lambda stream, rec: written.append(rec))
+
+    cfg = {
+        "streams": "orders",
+        "url": "http://x/orders?page={current_page_one_base}",
+        "datetime_keys": {"orders": "modified"},
+        "url_param_datetime_format": "%Y-%m-%dT%H:%M:%S.%f",
+        "items_per_page": 100,
+        "assume_sorted": False,
+        "filter_by_schema": False,
+        "auth_method": "no_auth",
+        "page_start": 0,
+        "offset_start": 0,
+    }
+    s = S.Sync(cfg, {}, None)
+    s.started_at = datetime.datetime.now()
+    # schema intentionally has NO _sdc_extracted_at property
+    schema = {"type": "object",
+              "properties": {"id": {"type": "integer"},
+                             "modified": {"type": "string", "format": "date-time"}}}
+    params = dict(cfg, current_page=0, current_offset=0,
+                  last_update="2026-01-01T00:00:00.000000")
+    with S.metrics.record_counter("orders") as counter:
+        completed, last_update, prev = s._drain_pages(
+            "orders", params, schema, None, "2026-01-01T00:00:00.000000",
+            None, counter, raw_output=False)
+
+    assert completed is True
+    assert len(written) == 1
+    assert "_sdc_extracted_at" not in written[0]

--- a/tests/unit/test_windows.py
+++ b/tests/unit/test_windows.py
@@ -14,9 +14,9 @@ from tap_rest_api.helper import (
 
 def _win_end(cfg, start_str, k, size=3600):
     """The kth window's exclusive end, computed exactly as the tap does (via the
-    same epoch round-trip), so assertions are independent of the host timezone."""
+    same UTC epoch round-trip), so assertions are independent of the host timezone."""
     start_epoch = parse_datetime_tz(start_str).timestamp()
-    return format_datetime(cfg, datetime.datetime.fromtimestamp(start_epoch + k * size))
+    return format_datetime(cfg, datetime.datetime.utcfromtimestamp(start_epoch + k * size))
 
 
 def test_windows_contiguous_and_clamped():
@@ -61,10 +61,12 @@ def test_windowed_params_datetime_bookmark():
         "page_start": 0,
         "offset_start": 0,
     }
-    w_start = datetime.datetime(2026, 1, 1, 0, 0, 0).timestamp()
+    # UTC epoch for 2026-01-01T00:00:00Z (the window epochs are UTC)
+    w_start = datetime.datetime(2026, 1, 1, 0, 0, 0,
+                                tzinfo=datetime.timezone.utc).timestamp()
     w_end = w_start + 3600
     params = get_windowed_endpoint_params(cfg, "orders", w_start, w_end)
-    # bounds are formatted for the URL and are exactly one hour apart
+    # bounds are formatted (UTC) for the URL and are exactly one hour apart
     assert params["start_datetime"] == "2026-01-01T00:00:00.000000"
     assert params["end_datetime"] == "2026-01-01T01:00:00.000000"
     assert params["datetime_key"] == "modified"

--- a/tests/unit/test_windows.py
+++ b/tests/unit/test_windows.py
@@ -1,0 +1,164 @@
+import datetime
+import json
+import urllib.parse as urlparse
+
+import pytest
+
+from tap_rest_api.helper import (
+    iter_window_bounds,
+    get_windowed_endpoint_params,
+    format_datetime,
+    parse_datetime_tz,
+)
+
+
+def _win_end(cfg, start_str, k, size=3600):
+    """The kth window's exclusive end, computed exactly as the tap does (via the
+    same epoch round-trip), so assertions are independent of the host timezone."""
+    start_epoch = parse_datetime_tz(start_str).timestamp()
+    return format_datetime(cfg, datetime.datetime.fromtimestamp(start_epoch + k * size))
+
+
+def test_windows_contiguous_and_clamped():
+    # last window is clamped to the end; windows are contiguous and half-open
+    assert list(iter_window_bounds(0, 10, 3)) == [(0.0, 3.0), (3.0, 6.0), (6.0, 9.0), (9.0, 10.0)]
+
+
+def test_windows_exact_multiple():
+    assert list(iter_window_bounds(0, 9, 3)) == [(0.0, 3.0), (3.0, 6.0), (6.0, 9.0)]
+
+
+def test_windows_empty_when_start_ge_end():
+    assert list(iter_window_bounds(5, 5, 3)) == []
+    assert list(iter_window_bounds(7, 5, 3)) == []
+
+
+def test_windows_single_when_window_larger_than_range():
+    assert list(iter_window_bounds(0, 2, 3600)) == [(0.0, 2.0)]
+
+
+def test_windows_cover_without_gaps_or_overlaps():
+    start, end, size = 100.0, 100.0 + 3 * 3600 + 500, 3600
+    windows = list(iter_window_bounds(start, end, size))
+    # contiguous: each window's end is the next window's start
+    assert all(windows[i][1] == windows[i + 1][0] for i in range(len(windows) - 1))
+    # covers exactly [start, end]
+    assert windows[0][0] == start
+    assert windows[-1][1] == end
+
+
+def test_windows_reject_nonpositive_size():
+    with pytest.raises(ValueError):
+        list(iter_window_bounds(0, 10, 0))
+    with pytest.raises(ValueError):
+        list(iter_window_bounds(0, 10, -5))
+
+
+def test_windowed_params_datetime_bookmark():
+    cfg = {
+        "datetime_keys": {"orders": "modified"},
+        "url_param_datetime_format": "%Y-%m-%dT%H:%M:%S.%f",
+        "page_start": 0,
+        "offset_start": 0,
+    }
+    w_start = datetime.datetime(2026, 1, 1, 0, 0, 0).timestamp()
+    w_end = w_start + 3600
+    params = get_windowed_endpoint_params(cfg, "orders", w_start, w_end)
+    # bounds are formatted for the URL and are exactly one hour apart
+    assert params["start_datetime"] == "2026-01-01T00:00:00.000000"
+    assert params["end_datetime"] == "2026-01-01T01:00:00.000000"
+    assert params["datetime_key"] == "modified"
+    # pagination resets; last_update seeds the window start
+    assert params["current_page"] == 0
+    assert params["current_offset"] == 0
+    assert params["last_update"] == params["start_datetime"]
+
+
+def test_windowed_params_requires_time_bookmark():
+    cfg = {"index_keys": {"orders": "id"}}
+    with pytest.raises(ValueError):
+        get_windowed_endpoint_params(cfg, "orders", 0, 3600)
+
+
+def _windowing_config():
+    return {
+        "streams": "orders",
+        "url": ("http://x/orders?page={current_page_one_base}"
+                "&modified__gte={start_datetime}&modified__lt={end_datetime}"),
+        "datetime_keys": {"orders": "modified"},
+        "url_param_datetime_format": "%Y-%m-%dT%H:%M:%S.%f",
+        "items_per_page": 100,
+        "assume_sorted": False,
+        "filter_by_schema": False,
+        "auth_method": "no_auth",
+        "page_start": 0,
+        "offset_start": 0,
+    }
+
+
+def test_sync_windowed_checkpoints_each_drained_window(monkeypatch):
+    """Three 1h windows -> three checkpoints, bookmark advancing to each window end."""
+    import tap_rest_api.sync as S
+    import tap_rest_api.schema as SC
+
+    # Fake API honoring the ?modified__gte=&modified__lt= filter: one record per
+    # window dated at the window start; page 2 is empty (signals the window's end).
+    def fake_request(stream, endpoint, *a, **k):
+        q = urlparse.parse_qs(urlparse.urlparse(endpoint).query)
+        if q.get("page", ["1"])[0] != "1":
+            return []
+        return [{"id": 1, "modified": q["modified__gte"][0]}]
+
+    monkeypatch.setattr(S, "generate_request", fake_request)
+    monkeypatch.setattr(SC.Schema, "validate", staticmethod(lambda rec, sch: (True, None)))
+    states = []
+    monkeypatch.setattr(S.singer, "write_state", lambda st: states.append(json.loads(json.dumps(st))))
+    monkeypatch.setattr(S.singer, "write_record", lambda *a, **k: None)
+
+    s = S.Sync(_windowing_config(), {}, None)
+    s.started_at = datetime.datetime.now()
+    schema = {"type": "object",
+              "properties": {"id": {"type": "integer"},
+                             "modified": {"type": "string", "format": "date-time"},
+                             "_sdc_extracted_at": {"type": "string", "format": "date-time"}}}
+    with S.metrics.record_counter("orders") as counter:
+        final = s._sync_windowed(
+            {}, "orders", schema,
+            "2026-01-01T00:00:00.000000", "2026-01-01T03:00:00.000000",
+            "datetime", 3600, None, counter, raw_output=False)
+
+    cfg = _windowing_config()
+    bm = lambda st: st["bookmarks"]["orders"]["last_update"]
+    assert len(states) == 3
+    assert bm(states[0]) == _win_end(cfg, "2026-01-01T00:00:00.000000", 1)
+    assert bm(states[1]) == _win_end(cfg, "2026-01-01T00:00:00.000000", 2)
+    assert bm(final) == _win_end(cfg, "2026-01-01T00:00:00.000000", 3)
+
+
+def test_sync_windowed_does_not_advance_past_incomplete_window(monkeypatch):
+    """If a window is cut short, the bookmark stays at the last fully-drained window."""
+    import tap_rest_api.sync as S
+
+    calls = {"n": 0}
+
+    def fake_drain(self, stream, params, schema, end, last_update, prev, counter, raw):
+        calls["n"] += 1
+        completed = (calls["n"] == 1)  # window 1 drains; window 2 is cut short
+        return completed, last_update, prev
+
+    monkeypatch.setattr(S.Sync, "_drain_pages", fake_drain)
+    states = []
+    monkeypatch.setattr(S.singer, "write_state", lambda st: states.append(json.loads(json.dumps(st))))
+
+    s = S.Sync(_windowing_config(), {}, None)
+    s.started_at = datetime.datetime.now()
+    final = s._sync_windowed(
+        {}, "orders", {},
+        "2026-01-01T00:00:00.000000", "2026-01-01T03:00:00.000000",
+        "datetime", 3600, None, None, raw_output=False)
+
+    # only window 1 checkpointed; bookmark left at window-1 end (not leapfrogged forward)
+    assert len(states) == 1
+    assert (final["bookmarks"]["orders"]["last_update"]
+            == _win_end(_windowing_config(), "2026-01-01T00:00:00.000000", 1))
+    assert calls["n"] == 2  # tried window 2, saw it incomplete, stopped

--- a/uv.lock
+++ b/uv.lock
@@ -462,7 +462,7 @@ wheels = [
 
 [[package]]
 name = "tap-rest-api"
-version = "0.2.17"
+version = "0.2.18"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Problem

For an incremental keyed on a datetime/timestamp bookmark, the tap issues one open-ended request (`...>= bookmark`), advances the bookmark to the max value seen, and writes state once at the end. If a run is cut short — `global_timeout`, a mid-stream error, or the `assume_sorted` early-exit — **before it fully drains**, the bookmark still advances past records that were never fetched. Those records are stranded and silently lost. This is especially damaging for APIs whose results are **not sorted by the bookmark key** (pagination order ≠ bookmark order).

## Fix

Opt-in **bounded, fully-drained time windows**. With a datetime/timestamp bookmark and `window_size_seconds`/`window_size_hours` set, the tap replicates in **contiguous, half-open windows** and **checkpoints the bookmark to a window's upper bound only after that window is completely drained**. A window cut short leaves the bookmark at the last completed boundary, so the next run resumes there.

- No leapfrog past unfetched records — a timeout becomes a safe stall, not silent loss.
- Sort order no longer affects completeness: draining a bounded window returns every matching record regardless of order.
- Self-healing: small windows complete within the run budget and commit incrementally.

## Config (opt-in)

Unset ⇒ existing single-request behavior, unchanged.

```json
{
  "assume_sorted": false,
  "window_size_hours": 6,
  "url": ".../items?page={current_page_one_base}&modified__gte={start_datetime}&modified__lt={end_datetime}"
}
```

The URL must bound **both** ends of the bookmark field (`__gte={start_datetime}` and `__lt={end_datetime}`).

## Changes

- `helper.py`: `iter_window_bounds` (contiguous, half-open, clamped) and `get_windowed_endpoint_params`.
- `sync.py`: extract the page loop into `_drain_pages` (returns a `completed` flag); add `_sync_windowed` (checkpoint per fully-drained window). The non-windowed path is behavior-preserving.
- `default_spec.json`: `window_size_seconds` / `window_size_hours`.
- `main.py`: support the `number` (float) config-arg type.

## Testing

Unit tests in `tests/unit/test_windows.py` and `tests/unit/test_fixes.py` cover the window arithmetic (coverage / contiguity / clamping), checkpoint-per-drained-window, and — critically — the bookmark **not** advancing past an incomplete window. Full suite: **19 passed**.

Beyond unit tests, the change was validated end-to-end against a **real, high-volume API** (a SaaSOptics transactions stream) through the production ETL runner, with the destination replaced by a local file dump so **nothing was written downstream**. For each run the distinct record ids actually emitted were reconciled against the API's authoritative `count` for the exact time range; every source record must be either emitted or explained by a **logged** drop (a boundary dedup), otherwise it is counted as silent loss. Both the current config and the windowed config were run from the same baseline, at two scales:

| run | config | emitted | API source count | pages | windows / ckpts | silent loss? |
| --- | --- | --- | --- | --- | --- | --- |
| Live A | current | 45 | 46 | 1 | – | **NO** |
| Live B | windowed | 45 | 46 | 2 | 2 / 2 | **NO** |
| Stress A | current | 14,249 | 14,249 | 143 | – | **NO** |
| Stress B | windowed | 14,254 | 14,254 | 145 | 4 / 4 | **NO** |

- Every run reconciles **exactly** to the source. The only non-zero gap (Live = 1) is the inclusive-`__gte` boundary record already emitted by the previous run — correctly **logged** as a dedup skip. Zero schema-invalid drops, zero CRITICALs, zero timeouts.
- The current and windowed configs emitted the **identical** id set over the same range (Stress B is a strict superset of A only because 5 records became visible in the source between the two sequential runs — live drift, not loss).
- The windowed path checkpoints the bookmark **only** to fully-drained window boundaries (verified 2/2 and 4/4 windows); the current path advances to max-seen, which is safe only on a complete drain.

## Related fixes folded in

Three defects found during that testing, each with a regression test in `tests/unit/test_fixes.py`:

- **#38** — `get_end()` used naive local `datetime.now()`; on a non-UTC host the incremental end bound skews (it emitted 0 records on a UTC−7 host). Now uses an explicit UTC now, and the windowing param builder converts window epochs with `utcfromtimestamp`.
- **#39** — the datetime/timestamp/index key type-validation asserts were written `assert(cond, "msg")` (an always-true tuple) and never fired; parentheses removed.
- **#40** — `record.pop(EXTRACT_TIMESTAMP)` was unconditional though the field is only added when the schema declares it; pop with a default to avoid `KeyError` on schemas without `_sdc_extracted_at`.

## Compatibility

Fully opt-in. Without `window_size_*`, behavior is unchanged. The #38/#39/#40 fixes are host- and config-agnostic (UTC was already the established "now" elsewhere in the tap).
